### PR TITLE
Change label animation from container scale to fontSize

### DIFF
--- a/lib/ErrorHelper.js
+++ b/lib/ErrorHelper.js
@@ -1,10 +1,11 @@
 import React, { Component } from 'react'
-import { Text } from 'react-native'
+import { Text, View } from 'react-native'
 import PropTypes from 'prop-types'
 
 export default class extends Component {
   static propTypes = {
     error: PropTypes.string,
+    errorIcon: PropTypes.node,
     errorPaddingTop: PropTypes.number,
     errorColor: PropTypes.string,
     errorFontSize: PropTypes.number
@@ -17,17 +18,20 @@ export default class extends Component {
   }
 
   render() {
-    let { error, errorColor, errorPaddingTop, errorFontSize } = this.props
+    let { error, errorIcon, errorColor, errorPaddingTop, errorFontSize } = this.props
 
     return (
-      <Text
-        style={{
-          paddingTop: errorPaddingTop,
-          color: errorColor,
-          fontSize: errorFontSize
-        }}>
-        {error}
-      </Text>
+      <View style={{flexDirection: 'row', alignItems: 'center', marginTop: errorPaddingTop}}>
+        {errorIcon}
+        <Text
+          style={{
+            paddingLeft: errorIcon ? errorPaddingTop : 0,
+            color: errorColor,
+            fontSize: errorFontSize,
+          }}>
+          {error || ' '}
+        </Text>
+      </View>
     )
   }
 }

--- a/lib/ErrorHelper.js
+++ b/lib/ErrorHelper.js
@@ -8,7 +8,8 @@ export default class extends Component {
     errorIcon: PropTypes.node,
     errorPaddingTop: PropTypes.number,
     errorColor: PropTypes.string,
-    errorFontSize: PropTypes.number
+    errorFontSize: PropTypes.number,
+    fontFamily: PropTypes.string
   }
 
   static defaultProps = {
@@ -18,7 +19,7 @@ export default class extends Component {
   }
 
   render() {
-    let { error, errorIcon, errorColor, errorPaddingTop, errorFontSize } = this.props
+    let { error, errorIcon, errorColor, errorPaddingTop, errorFontSize, fontFamily } = this.props
 
     return (
       <View style={{flexDirection: 'row', alignItems: 'center', marginTop: errorPaddingTop}}>
@@ -28,6 +29,7 @@ export default class extends Component {
             paddingLeft: errorIcon ? errorPaddingTop : 0,
             color: errorColor,
             fontSize: errorFontSize,
+            fontFamily: fontFamily,
           }}>
           {error || ' '}
         </Text>

--- a/lib/Input.js
+++ b/lib/Input.js
@@ -85,7 +85,7 @@ export default class extends Component {
       labelColor,
       labelActiveTop,
       labelActiveColor,
-      labelActiveScale,
+      labelActiveFontSize,
       placeholder,
       placeholderColor,
       underlineDuration,
@@ -94,6 +94,7 @@ export default class extends Component {
       underlineActiveColor,
       underlineActiveHeight,
       error,
+      errorIcon,
       errorColor,
       errorPaddingTop,
       errorFontSize,
@@ -113,7 +114,7 @@ export default class extends Component {
       labelColor,
       labelActiveTop,
       labelActiveColor,
-      labelActiveScale,
+      labelActiveFontSize,
       focused,
       hasValue,
       error,
@@ -174,6 +175,7 @@ export default class extends Component {
     }
     let errorProps = {
       error,
+      errorIcon,
       errorColor,
       errorPaddingTop,
       errorFontSize
@@ -195,7 +197,7 @@ export default class extends Component {
           ref={this._handleTextInputRef}
         />
         <Underline {...underlineProps} />
-        {error ? <ErrorHelper {...errorProps} /> : null}
+        <ErrorHelper {...errorProps} />
       </View>
     )
   }

--- a/lib/Input.js
+++ b/lib/Input.js
@@ -178,7 +178,8 @@ export default class extends Component {
       errorIcon,
       errorColor,
       errorPaddingTop,
-      errorFontSize
+      errorFontSize,
+      fontFamily,
     }
 
     return (

--- a/lib/Label.js
+++ b/lib/Label.js
@@ -8,7 +8,7 @@ export default class extends Component {
     labelDuration: PropTypes.number,
     labelColor: PropTypes.string,
     labelActiveColor: PropTypes.string,
-    labelActiveScale: PropTypes.number,
+    labelActiveFontSize: PropTypes.number,
     labelActiveTop: PropTypes.number
   }
 
@@ -16,28 +16,28 @@ export default class extends Component {
     labelDuration: 200,
     labelColor: 'gray',
     labelActiveColor: '#3f51b5',
-    labelActiveScale: 0.8,
+    labelActiveFontSize: 12,
     labelActiveTop: -18
   }
 
   constructor(props) {
     super(props)
 
-    let { hasValue, focused, labelActiveScale, labelActiveTop } = props
+    let { hasValue, focused, labelActiveFontSize, fontSize, labelActiveTop } = props
 
     this.state = {
-      animatedScale: new Animated.Value(hasValue || focused ? labelActiveScale : 1),
+      animatedScale: new Animated.Value(hasValue || focused ? labelActiveFontSize / fontSize : 1),
       animatedTranslate: new Animated.Value(hasValue || focused ? labelActiveTop : 0)
     }
   }
 
   componentWillReceiveProps = nextProps => {
     let { animatedScale, animatedTranslate } = this.state
-    let { labelDuration, labelActiveScale, labelActiveTop, hasValue, focused } = nextProps
+    let { labelDuration, labelActiveFontSize, labelActiveTop, hasValue, focused, fontSize } = nextProps
 
     if (this.props.hasValue !== hasValue || this.props.focused !== focused) {
       Animated.timing(animatedScale, {
-        toValue: hasValue || focused ? labelActiveScale : 1,
+        toValue: hasValue || focused ? labelActiveFontSize / fontSize : 1,
         duration: labelDuration,
       }).start()
 
@@ -62,6 +62,7 @@ export default class extends Component {
       label,
       labelColor,
       labelActiveColor,
+      labelActiveFontSize,
       error,
       errorColor
     } = this.props
@@ -85,7 +86,7 @@ export default class extends Component {
           style={{
             paddingRight,
             paddingLeft,
-            color: error ? errorColor : focused ? activeColor || labelActiveColor : labelColor,
+            color: focused ? activeColor || labelActiveColor : labelColor,
             fontFamily,
             fontSize: scaledFontSize,
             fontWeight

--- a/lib/Label.js
+++ b/lib/Label.js
@@ -39,7 +39,6 @@ export default class extends Component {
       Animated.timing(animatedScale, {
         toValue: hasValue || focused ? labelActiveScale : 1,
         duration: labelDuration,
-        useNativeDriver: true
       }).start()
 
       Animated.timing(animatedTranslate, {
@@ -68,29 +67,31 @@ export default class extends Component {
     } = this.props
     let { animatedScale, animatedTranslate } = this.state
 
+    scaledFontSize = animatedScale.interpolate({
+      inputRange: [0, 1],
+      outputRange: [fontSize * 0, fontSize * 1],
+    });
+
     return (
       <Animated.View
         style={{
           position: 'absolute',
-          width: '200%',
-          marginLeft: '-100%',
+          width: '100%',
           top: paddingTop,
-          transform: [{ translateY: animatedTranslate }, { scale: animatedScale }]
+          transform: [{ translateY: animatedTranslate }],
         }}
         numberOfLines={1}>
-        <Text
+        <Animated.Text
           style={{
-            left: '50%',
-            top: 0,
             paddingRight,
             paddingLeft,
             color: error ? errorColor : focused ? activeColor || labelActiveColor : labelColor,
             fontFamily,
-            fontSize,
+            fontSize: scaledFontSize,
             fontWeight
           }}>
           {label}
-        </Text>
+        </Animated.Text>
       </Animated.View>
     )
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-material-textinput",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Textual input component for React Native",
   "license": "MIT",
   "author": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-material-textinput",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Textual input component for React Native",
   "license": "MIT",
   "author": {


### PR DESCRIPTION
Animate fontSize instead of container scale. The container scale with 200% width and negative marginLeft causes overlapping issues when you have fields next to each other.